### PR TITLE
Add Waffle-block style tabs, refactor tab and layout code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BoxMaker: A free tool for creating boxes using tabbed construction
 
-_version 0.95 - 20 Apr 2017_
+_version 0.96 - 24 Apr 2017_
 
 Original box maker by Elliot White - http://www.twot.eu/111000/111000.html
 Heavily modified by Paul Hutchison
@@ -47,6 +47,12 @@ In order of appearance:
                                  equally into tabs and 'spaces' with the tabs size 
                                  greater or equal to the Tab Width setting
 
+* Tab Style - there are three styles of tabs avaiable:
+    * XY Symmetrix - each piece is symmetric in both the X and Y axes
+    * Rotate Symmetric ("waffle block") - each piece is symmetric under a 180-degree rotation
+      (and 90 degrees if that piece is square)
+    * Antisymmetric - tabs on opposite sides go in opposite directions
+
 * Tab Dimple Height - the height of the dimple to add to the side of each tab, 0 for no dimple
 
 * Tab Dimple Tip Width - the width of the tip of the dimple; dimples are trapezoid shaped with
@@ -60,13 +66,9 @@ In order of appearance:
 * Clearance - this value is subtracted from the kerf in cases where you deliberately want
              slightly slacker joints ( usually zero )
 
-* Layout/Style - { This is where additions/changes will most likely occur, also having a
-                problem with live preview: it is best to turn preview off when changing this 
-                setting }
-                this setting determines both the type of drawing produced and the way tabs
-                are used on the sides of pieces.
+* Layout - controls how the pieces are laid out in the drawing
 
-* Box style - this allows you to choose how many jointed sides you want. Options are:
+* Box Type - this allows you to choose how many jointed sides you want. Options are:
     * Fully enclosed (6 sides)
     * One side open (LxW) - one of the Length x Width panels will be omitted
     * Two sides open (LxW and LxH) - two adjacent panels will be omitted
@@ -77,8 +79,9 @@ In order of appearance:
 
 			
 * Dividers (Length axis) - use this to create additional LxH panels that mount inside the box 
-						 along the length axis and have finger joints into the side panels
-						 and slots for Width dividers to slot into
+  along the length axis and have finger joints into the side panels
+  and slots for Width dividers to slot into
+    * Note: dividers only work properly when using XY-symetric tabs
 				
 * Dividers (Width axis) - use this to create additional WxH panels that mount inside the box 
 						 along the width axis and have finger joints into the side panels
@@ -91,6 +94,8 @@ In order of appearance:
 	* All Sides
 				
 * Space Between Parts - how far apart the pieces are in the drawing produced
+
+* Live Preview - you may need to turn this off when changing tab style, box type, or layout
 
 ## Use - Schroff enclosures
 
@@ -128,3 +133,4 @@ version | Date | Notes
 0.93a | (21 Sept 2015) | Added hairline line thickness option for Epilog lasers
 0.94 | (4 Jan 2017) | Divider keying options
 0.95 | (20 Apr 2017) | Added optional dimples on tabs
+0.96 | (24 Apr 2017) | Orthogonalized box type, layout, tab style; added rotate-symmetric tabs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BoxMaker: A free tool for creating boxes using tabbed construction
 
-_version 0.94 - 5 Jan 2017_
+_version 0.95 - 20 Apr 2017_
 
 Original box maker by Elliot White - http://www.twot.eu/111000/111000.html
 Heavily modified by Paul Hutchison
@@ -13,7 +13,7 @@ Heavily modified by Paul Hutchison
 ## Release Notes
  So far no serious bugs( i.e causing runtime errors ) have been found. The program works with python versions 2.6.5, 2.6.7 and 2.7.2, other version have not yet been tried except python 2.5.1 which fails with a syntax error.
 
-This version has been tried on windows XP, windows 7, Ubuntu and Mac OS X with no serious problems ( the live preview works most of the time but can be flaky).
+Version 0.94 has been tried on windows XP, windows 7, Ubuntu and Mac OS X with no serious problems ( the live preview works most of the time but can be flaky).
 
  Only crude input checking has been implemented in the program but as the only output is a drawing the worst that can happen is a messed up picture ( control-Z cures that problem ).
  
@@ -46,6 +46,11 @@ In order of appearance:
                                  Width, for proportional the side of a piece is divided 
                                  equally into tabs and 'spaces' with the tabs size 
                                  greater or equal to the Tab Width setting
+
+* Tab Dimple Height - the height of the dimple to add to the side of each tab, 0 for no dimple
+
+* Tab Dimple Tip Width - the width of the tip of the dimple; dimples are trapezoid shaped with
+  45-degree sides; using a dimple tip width of 0 gives a triangular dimple
 
 * Material Thickness - as it says
  
@@ -122,3 +127,4 @@ version | Date | Notes
 0.93 | (21 Sept 2015) | Updated versioning to match original author's updated v0.91 plus adding my 0.02 
 0.93a | (21 Sept 2015) | Added hairline line thickness option for Epilog lasers
 0.94 | (4 Jan 2017) | Divider keying options
+0.95 | (20 Apr 2017) | Added optional dimples on tabs

--- a/boxmaker.inx
+++ b/boxmaker.inx
@@ -28,6 +28,11 @@
     <_option value="1">Proportional</_option>
   </param>
 
+  <param name="dimpleheight" type="float" precision="2" min="0.0" max="10000.0"
+    _gui-text="Tab Dimple Height">0.0</param>
+  <param name="dimplelength" type="float" precision="2" min="0.0" max="10000.0"
+    _gui-text="Tab Dimple Tip Length">0.0</param>
+
   <param name="hairline" type="optiongroup" _gui-text="Line Thickness" appearance="minimal">
     <_option value="0">Default</_option>
     <_option value="1">Hairline (0.002" for Epilog)</_option>

--- a/boxmaker.inx
+++ b/boxmaker.inx
@@ -28,6 +28,12 @@
     <_option value="1">Proportional</_option>
   </param>
 
+  <param name="tabstyle" type="optiongroup" _gui-text="Tab Style" appearance="minimal">
+    <_option value="0">XY Symmetric</_option>
+    <_option value="1">Rotate Symmetric</_option>
+    <_option value="2">Antisymmetric</_option>
+  </param>
+
   <param name="dimpleheight" type="float" precision="2" min="0.0" max="10000.0"
     _gui-text="Tab Dimple Height">0.0</param>
   <param name="dimplelength" type="float" precision="2" min="0.0" max="10000.0"
@@ -42,11 +48,10 @@
   <param name="kerf" type="float" precision="3"  min="0.0" max="10000.0" _gui-text="Kerf (cut width)">0.1</param>
   <param name="clearance" type="float" precision="3"  min="0.0" max="10000.0" _gui-text="Joint clearance">0.01</param>
 	
-  <param name="style" _gui-text="Layout/Style" type="optiongroup" appearance="minimal">
+  <param name="style" _gui-text="Layout" type="optiongroup" appearance="minimal">
     <option value="1">Diagramatic</option>
     <option value="2">3 piece</option>
     <option value="3">Inline(compact)</option>
-    <option value="4">Diag Alternate Tabs</option>
   </param>
 
   <param name="boxtype" _gui-text="Box Type" type="optiongroup" appearance="minimal">


### PR DESCRIPTION
This branch is based on my dimples branch rather than master, but as the PR for dimples is still outstanding, this PR is against master, so accepting this PR will also pull in the dimples code if the dimples PR has not been merged.

In this PR, I have refactored the box style, layout, and tab generation code to be orthogonal, so you can mix and match among them as desired. As part of that refactoring, there were a few obscure bugs that got fixed. Also, the location of the tabs on each box face is no longer a function of the selected box type or layout, so the specific tab positions are different for some combinations of those values than before this change.

The box type now controls only which faces are included in the output, and which sides of the remaining faces do or do not have tabs. The location of all tabs that remain are not a function of the box type.

In the layout, when an entire row or column of pieces is missing due to the selected box type not having a complete set of faces, the remaining rows or columns are shifted so as to keep the layout compact.

The new Rotate-Symmetric tab type allows producing Waffle-block style tabs. In particular, if making a cube, all faces will have the identical shape and are thus interchangeable.

The size of the faces on open boxes is now a function of the box-dimensions inner/outer choice. The concept here is that, when a face is missing, the outer dimension is no longer the inner dimension plus the material thickness, because that side doesn't exist. If outer is specified, the code now produces a result that will exactly fit inside an enclosing box with those inner dimensions; if inner is specified, then a box of the specified dimensions will exactly fit inside the produced box, flush with the open faces of the box.

Dividers only work properly with XY-symmetric tabs (the previous primary style). They previously did not work with the "alternate tab style" (which is called Antisymmetric in this change), and I did not investigate that part of the code nor attempt to make them work with the new Rotate-symmetric tab style.

Here is a screenshot showing the box dialog along with a generated box that uses the Rotate-symmetric waffle-block style tabs.

<img width="1179" alt="screen shot 2017-04-24 at 12 27 47 pm" src="https://cloud.githubusercontent.com/assets/116825/25361547/9d8c809a-2903-11e7-9aa6-738c75aae090.png">
