### PR TITLE
fix to make it work on inkscape1.0

### DIFF
--- a/boxmaker.inx
+++ b/boxmaker.inx
@@ -3,7 +3,7 @@
 	<_name>Tabbed Box Maker</_name>
 	<id>eu.twot.render.boxmaker</id>
 
-	<dependency type="executable" location="extensions">boxmaker.py</dependency>
+	<!--dependency type="executable" location="extensions">boxmaker.py</dependency-->
 	<hbox>
 		<vbox>
 			<label>Dimensions</label>

--- a/schroffmaker.inx
+++ b/schroffmaker.inx
@@ -3,9 +3,9 @@
   <_name>Schroff Box Maker</_name>
   <id>eu.twot.render.schroffboxmaker</id>
 
-  <dependency type="executable" location="extensions">boxmaker.py</dependency>
+  <!--dependency type="executable" location="extensions">boxmaker.py</dependency>
   <dependency type="executable" location="extensions">simpletransform.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex.py</dependency-->
 
   <param name="unit" type="string" gui-hidden="true">mm</param>
   <param name="inside" type="string" gui-hidden="true">1</param>
@@ -46,6 +46,6 @@
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">boxmaker.py</command>
+    <command location="inx" interpreter="python">boxmaker.py</command>
   </script>
 </inkscape-extension>


### PR DESCRIPTION
Commented out <dependency> tags in inx files to make it compatible with inkscape 1.0 (1.0+r73+1), which is the latest stable release as of this writing.
In its existing state, the extension is greyed out in the menu. The solution is to remove dependency tags, as described here: https://wiki.inkscape.org/wiki/index.php/Updating_your_Extension_for_1.0#Updating_.2A.inx_files

So, I have commented them out and it is working fine now.